### PR TITLE
Fixes #17 - configures Rails allowed hosts via env variables

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -12,6 +12,14 @@ Rails.application.configure do
   # Show full error reports.
   config.consider_all_requests_local = true
 
+  # Allowed hosts
+  if ENV["ALLOWED_HOST_REGEX"].present?
+    config.hosts << Regexp.new(ENV['ALLOWED_HOST_REGEX'])
+  end
+  if ENV['HOST_NAME'].present?
+    config.hosts << ENV['HOST_NAME']
+  end
+
   # Enable/disable caching. By default caching is disabled.
   # Run rails dev:cache to toggle caching.
   if Rails.root.join("tmp", "caching-dev.txt").exist?

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -13,8 +13,8 @@ Rails.application.configure do
   config.consider_all_requests_local = true
 
   # Allowed hosts
-  if ENV["ALLOWED_HOST_REGEX"].present?
-    config.hosts << Regexp.new(ENV['ALLOWED_HOST_REGEX'])
+  if ENV["ALLOWED_HOSTS_REGEX"].present?
+    config.hosts << Regexp.new(ENV['ALLOWED_HOSTS_REGEX'])
   end
   if ENV['HOST_NAME'].present?
     config.hosts << ENV['HOST_NAME']

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -17,6 +17,14 @@ Rails.application.configure do
   config.consider_all_requests_local = true
   config.action_controller.perform_caching = true
 
+  # Allowed hosts
+  if ENV["ALLOWED_HOST_REGEX"].present?
+    config.hosts << Regexp.new(ENV['ALLOWED_HOST_REGEX'])
+  end
+  if ENV['HOST_NAME'].present?
+    config.hosts << ENV['HOST_NAME']
+  end
+
   # Ensures that a master key has been made available in either ENV["RAILS_MASTER_KEY"]
   # or in config/master.key. This key is used to decrypt credentials (and other encrypted files).
   # config.require_master_key = true

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -18,8 +18,8 @@ Rails.application.configure do
   config.action_controller.perform_caching = true
 
   # Allowed hosts
-  if ENV["ALLOWED_HOST_REGEX"].present?
-    config.hosts << Regexp.new(ENV['ALLOWED_HOST_REGEX'])
+  if ENV["ALLOWED_HOSTS_REGEX"].present?
+    config.hosts << Regexp.new(ENV['ALLOWED_HOSTS_REGEX'])
   end
   if ENV['HOST_NAME'].present?
     config.hosts << ENV['HOST_NAME']

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -23,6 +23,14 @@ Rails.application.configure do
   config.consider_all_requests_local = true
   config.action_controller.perform_caching = false
 
+  # Allowed hosts
+  if ENV["ALLOWED_HOST_REGEX"].present?
+    config.hosts << Regexp.new(ENV['ALLOWED_HOST_REGEX'])
+  end
+  if ENV['HOST_NAME'].present?
+    config.hosts << ENV['HOST_NAME']
+  end
+
   # Raise exceptions instead of rendering exception templates.
   config.action_dispatch.show_exceptions = false
 

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -24,8 +24,8 @@ Rails.application.configure do
   config.action_controller.perform_caching = false
 
   # Allowed hosts
-  if ENV["ALLOWED_HOST_REGEX"].present?
-    config.hosts << Regexp.new(ENV['ALLOWED_HOST_REGEX'])
+  if ENV["ALLOWED_HOSTS_REGEX"].present?
+    config.hosts << Regexp.new(ENV['ALLOWED_HOSTS_REGEX'])
   end
   if ENV['HOST_NAME'].present?
     config.hosts << ENV['HOST_NAME']

--- a/example.env
+++ b/example.env
@@ -7,6 +7,11 @@ SECRET_KEY_BASE="beefaroni"
 RAILS_ENV=development
 PUMA_ENV=development
 
+# If both ALLOWED_HOSTS_REGEX and HOST_NAME are populated, both will be allowed
+# ALLOWED_HOSTS_REGEX=/.*\.compute\.amazonaws\.com/
+ALLOWED_HOSTS_REGEX=
+HOST_NAME=
+
 BUNDLE_GEMFILE=Gemfile
 # BUNDLE_PATH=/app/scholarspace/bundle
 CH12N_TOOL=fits_servlet

--- a/example.env
+++ b/example.env
@@ -11,6 +11,7 @@ PUMA_ENV=development
 # ALLOWED_HOSTS_REGEX=/.*\.compute\.amazonaws\.com/
 ALLOWED_HOSTS_REGEX=
 HOST_NAME=
+# Restart nginx after modifying HOST_NAME and/or ALLOWED_HOSTS_REGEX
 
 BUNDLE_GEMFILE=Gemfile
 # BUNDLE_PATH=/app/scholarspace/bundle


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [X] Feature
- [X] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Adds two `.env` parameters, `ALLOWED_HOSTS_REGEX` and `HOST_NAME`; their values are appended to (initially empty) `Rails.application.config.hosts` so that Rails allows requests from the host and/or regex.   Note that both may be populated if desired.

## QA Instructions, Screenshots, Recordings

- Do not populate either `.env` parameter. Confirm that you get a Rails error when trying to access the application
- Populate just `HOST_NAME` with your host name (e.g. `ec2-1-2-3-4.us-west-2.compute.amazon.com`) and confirm that you can access the application
- Populate just `ALLOWED_HOSTS_REGEX` with a regex that should include your host name  (e.g. `.*\.compute\.amazonaws\.com/`) and confirm that you can access the application
- Populate both and confirm that you can access the application.
- If desired, try non-blank values that should (both, if using both variables) exclude your host name.

## Added/updated tests?

- [ ] Yes
- [x] No, and this is why:  See comment below
- [ ] I need help with writing tests

## [optional] Are there any post deployment tasks we need to perform?

Populate at least one of these parameters in `.env`