### PR TITLE
Adding GWJournalIssue support

### DIFF
--- a/app/controllers/hyrax/gw_journal_issues_controller.rb
+++ b/app/controllers/hyrax/gw_journal_issues_controller.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+module Hyrax
+  class GwJournalIssuesController < ApplicationController
+    # Adds Hyrax behaviors to the controller.
+    include Hyrax::WorksControllerBehavior
+    include Hyrax::BreadcrumbsForWorks
+    self.curation_concern_type = ::GwJournalIssue
+
+    # Use a Valkyrie aware form service to generate Valkyrie::ChangeSet style
+    # forms.
+    self.work_form_service = Hyrax::FormFactory.new
+  end
+end

--- a/app/forms/gw_journal_issue_form.rb
+++ b/app/forms/gw_journal_issue_form.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+
+# @see https://github.com/samvera/hyrax/wiki/Hyrax-Valkyrie-Usage-Guide#forms
+# @see https://github.com/samvera/valkyrie/wiki/ChangeSets-and-Dirty-Tracking
+class GwJournalIssueForm < Hyrax::Forms.PcdmObjectForm(GwWork)
+  include Hyrax.FormFields(:basic_metadata)
+  include Hyrax.FormFields(:academic_document)
+  include Hyrax.FormFields(:gw_journal_issue)
+
+  # Define custom form fields using the Valkyrie::ChangeSet interface
+  #
+  # property :my_custom_form_field
+
+  # if you want a field in the form, but it doesn't have a directly corresponding
+  # model attribute, make it virtual
+  #
+  # property :user_input_not_destined_for_the_model, virtual: true
+end

--- a/app/indexers/gw_journal_issue_indexer.rb
+++ b/app/indexers/gw_journal_issue_indexer.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+class GwJournalIssueIndexer < Hyrax::Indexers.PcdmObjectIndexer(
+  GwWork
+)
+  include Hyrax.Indexer(:basic_metadata)
+  include Hyrax.Indexer(:academic_document)
+  include Hyrax.Indexer(:gw_journal_issue)
+
+  # Uncomment this block if you want to add custom indexing behavior:
+  #  def to_solr
+  #    super.tap do |index_document|
+  #      index_document[:my_field_tesim]   = resource.my_field.map(&:to_s)
+  #      index_document[:other_field_ssim] = resource.other_field
+  #    end
+  #  end
+end

--- a/app/models/gw_journal_issue.rb
+++ b/app/models/gw_journal_issue.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class GwJournalIssue < AcademicDocument
+  include Hyrax.Schema(:basic_metadata)
+  include Hyrax.Schema(:academic_document)
+  include Hyrax.Schema(:gw_journal_issue)
+end

--- a/app/views/hyrax/gw_journal_issues/_gw_journal_issue.html.erb
+++ b/app/views/hyrax/gw_journal_issues/_gw_journal_issue.html.erb
@@ -1,0 +1,2 @@
+<%# This is a search result view %>
+<%= render 'catalog/document', document: gw_journal_issue, document_counter: gw_journal_issue_counter  %>

--- a/config/authorities/licenses.yml
+++ b/config/authorities/licenses.yml
@@ -1,25 +1,25 @@
 terms:
     - id: http://creativecommons.org/licenses/by/3.0/us/
       term: Attribution 3.0 United States
-      active: false
+      active: true
     - id: http://creativecommons.org/licenses/by-sa/3.0/us/
       term: Attribution-ShareAlike 3.0 United States
-      active: false
+      active: true
     - id: http://creativecommons.org/licenses/by-nc/3.0/us/
       term: Attribution-NonCommercial 3.0 United States
-      active: false
+      active: true
     - id: http://creativecommons.org/licenses/by-nd/3.0/us/
       term: Attribution-NoDerivs 3.0 United States
-      active: false
+      active: true
     - id: http://creativecommons.org/licenses/by-nc-nd/3.0/us/
       term: Attribution-NonCommercial-NoDerivs 3.0 United States
-      active: false
+      active: true
     - id: http://creativecommons.org/licenses/by-nc-sa/3.0/us/
       term: Attribution-NonCommercial-ShareAlike 3.0 United States
-      active: false
+      active: true
     - id: http://www.europeana.eu/portal/rights/rr-r.html
       term: All rights reserved
-      active: false
+      active: true
     - id: https://creativecommons.org/licenses/by/4.0/
       term: Creative Commons BY Attribution 4.0 International
       active: true

--- a/config/initializers/hyrax.rb
+++ b/config/initializers/hyrax.rb
@@ -9,6 +9,7 @@ Hyrax.config do |config|
     config.register_curation_concern :academic_document
     config.register_curation_concern :gw_work
     config.register_curation_concern :gw_etd
+    config.register_curation_concern :gw_journal_issue
     # Injected via `rails g hyrax:work_resource Page`
     config.register_curation_concern :derived_page
 
@@ -127,7 +128,7 @@ Hyrax.config do |config|
     # Should work creation require file upload, or can a work be created first
     # and a file added at a later time?
     # The default is true.
-    config.work_requires_files = true
+    config.work_requires_files = false
 
     # How many rows of items should appear on the work show view?
     # The default is 10

--- a/config/metadata/collection_resource.yaml
+++ b/config/metadata/collection_resource.yaml
@@ -22,19 +22,27 @@
 #  `rails generate hyrax:collection_resource CollectionResource`
 
 attributes:
-  target_audience:
-    type: string
-    form:
-      primary: true
-      multiple: true
-    predicate: http://hyrax-example.com/target_audience
-  department:
-    type: string
-    form:
-      primary: true
-    predicate: http://hyrax-example.com/department
-  course:
-    type: string
-    form:
-      primary: false
-    predicate: http://hyrax-example.com/course
+    target_audience:
+        type: string
+        form:
+            primary: true
+            multiple: true
+        predicate: http://hyrax-example.com/target_audience
+    department:
+        type: string
+        form:
+            primary: true
+        predicate: http://hyrax-example.com/department
+    course:
+        type: string
+        form:
+            primary: false
+        predicate: http://hyrax-example.com/course
+    bulkrax_identifier:
+        type: string
+        multiple: true
+        form:
+            primary: false
+        index_keys:
+            - "bulkrax_identifier_tesim"
+        predicate: https://iro.bl.uk/resource#bulkraxIdentifier

--- a/config/metadata/gw_journal_issue.yaml
+++ b/config/metadata/gw_journal_issue.yaml
@@ -1,0 +1,42 @@
+---
+attributes:
+    gw_affiliation:
+        type: string
+        multiple: true
+        form:
+            primary: false
+        index_keys:
+            - "gw_affiliation_tesim"
+        predicate: http://scholarspace.library.gwu.edu/ns#gwaffiliation
+    doi:
+        type: string
+        multiple: true
+        form:
+            primary: false
+        index_keys:
+            - "doi_tesim"
+        predicate: http://scholarspace.library.gwu.edu/ns#doi
+    bulkrax_identifier:
+        type: string
+        multiple: true
+        form:
+            primary: false
+        index_keys:
+            - "bulkrax_identifier_tesim"
+        predicate: https://iro.bl.uk/resource#bulkraxIdentifier
+    volume:
+        type: string
+        multiple: true
+        form:
+            primary: false
+        index_keys:
+            - "volume_tesim"
+        predicate: http://scholarspace.library.gwu.edu/ns#volume
+    issue:
+        type: string
+        multiple: true
+        form:
+            primary: false
+        index_keys:
+            - "issue_tesim"
+        predicate: http://scholarspace.library.gwu.edu/ns#issue


### PR DESCRIPTION
These changes add support for the GwJournalIssue type and for creating collections via Bulkrax.

To test: confirm that you are able to import works of the GwJournalIssue type and collections. (Note that the `creator` field is required for collections in this configuration, which may not have been the case in GWSS.)
