### PR TITLE
T36 limit admin routes

### DIFF
--- a/app/controllers/errors_controller.rb
+++ b/app/controllers/errors_controller.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class ErrorsController < ApplicationController
+  def not_found
+    render '/errors/not_found', status: 404
+  end
+end

--- a/app/views/errors/not_found.html.erb
+++ b/app/views/errors/not_found.html.erb
@@ -1,0 +1,30 @@
+<div class="container">
+  <div class="error-container">
+    <div class="error-header">
+      <h1>404: Page not found</h1>
+    </div>
+    <div class="error-content">
+      <p>Looks like something went wrong...</p>
+      <p>The link you have may be incorrect, or the page you're looking for may
+        have been removed or renamed.</p>
+      <h2 class="broken-links">Solutions for broken links</h2>
+      <div class="options">
+        <div class="option">
+          <h3>Find the page name</h3>
+          <p>Use the search bar to locate the page by name.</p>
+        </div>
+        <div class="option">
+          <h3>Start over</h3>
+          <p>Try
+            <%= link_to "starting from the homepage", "/" %>.</p>
+        </div>
+        <div class="option">
+          <h3>Contact us</h3>
+          <p>Reach out using the
+            <%= link_to "contact form", "/contact" %>
+            to let us know what you were looking for.</p>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -19,7 +19,9 @@ Rails.application.routes.draw do
   end
   devise_for :users
   mount Hydra::RoleManagement::Engine => '/'
-  mount Sidekiq::Web => '/sidekiq'
+  authenticate :user, ->(u) { u.admin? } do
+    mount Sidekiq::Web => '/sidekiq'
+  end
   mount Qa::Engine => '/authorities'
   mount Hyrax::Engine, at: '/'
   resources :welcome, only: 'index'
@@ -40,5 +42,7 @@ Rails.application.routes.draw do
 
     collection { delete 'clear' }
   end
+
+  match '*path', to: 'errors#not_found', via: :all, format: false, defaults: { format: 'html' }
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
 end

--- a/spec/features/sidekiq_dashboard_access_spec.rb
+++ b/spec/features/sidekiq_dashboard_access_spec.rb
@@ -1,0 +1,30 @@
+require 'rails_helper'
+
+RSpec.describe 'Sidekiq Dashboard Access' do
+  it 'loads sidekiq dashboard for a logged in admin user' do
+    admin_user = User.create(email: 'admin@example.com', password: 'password')
+    admin_user.roles << Role.find_or_create_by(name: 'admin')
+
+    sign_in_user(admin_user)
+
+    visit('/sidekiq')
+
+    expect(current_path).to eq('/sidekiq')
+  end
+
+  it 'redirects users to sign-in page if not logged in as admin' do
+    visit('/sidekiq')
+
+    expect(current_path).to eq('/users/sign_in')
+  end
+
+  it 'redirects to a 404 page if visited by logged in non-admin user' do
+    non_admin_user = User.create(email: 'not_an_admin@example.com', password: 'password')
+
+    sign_in_user(non_admin_user)
+
+    visit('/sidekiq')
+
+    expect(page).to have_content('404: Page not found')
+  end
+end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Just chipping away at the MVP tickets. This handles the redirection of non-admin users away from /sidekiq and adds a non-rails 404 page. 

## Related Tickets & Documents

- Related Issue #
- Closes #36 

## QA Instructions, Screenshots, Recordings
Run tests, should be 205 examples, 1 pending, 0 failing. 

To manually test 404 page, visit an invalid URL and ensure you don't see the rails error page - should see basic 404 page instead. 
<img width="905" height="474" alt="Screenshot 2026-02-25 at 1 29 59 PM" src="https://github.com/user-attachments/assets/675f0145-cbf5-4e6b-8c53-4da726b2d7cd" />

To manually test sidekiq access - sign in as admin user and visit /sidekiq, you should see the sidekiq dashboard. Sign out and visit /sidekiq, and you should see a 404 page. 

## Added/updated tests?

- [x] Yes
- [ ] No, and this is why: _please replace this line with details on why tests
      have not been included_
- [ ] I need help with writing tests

## [optional] Are there any post deployment tasks we need to perform?
