### PR TITLE
set up digital stacks homepage controller/view/route

### DIFF
--- a/app/controllers/digital_stacks_homepage_controller.rb
+++ b/app/controllers/digital_stacks_homepage_controller.rb
@@ -1,0 +1,4 @@
+class DigitalStacksHomepageController < ApplicationController
+  def show
+  end
+end

--- a/app/views/digital_stacks_homepage/show.html.erb
+++ b/app/views/digital_stacks_homepage/show.html.erb
@@ -1,0 +1,3 @@
+<h1>
+  Digital Stacks Homepage
+</h1>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,7 +3,7 @@ require 'sidekiq/web'
 Rails.application.routes.draw do
   concern :iiif_search, BlacklightIiifSearch::Routes.new
   mount Riiif::Engine => 'images', :as => :riiif if Hyrax.config.iiif_image_server?
-
+  get '/digitalstacks', to: 'digital_stacks_homepage#show'
   get '/uv/config/:id', to: 'application#uv_config', as: 'uv_config', defaults: { format: :json }
 
   mount Blacklight::Engine => '/'

--- a/spec/views/digital_stacks_homepage/show.html.erb_spec.rb
+++ b/spec/views/digital_stacks_homepage/show.html.erb_spec.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'digital_stacks_homepage/show', type: :view do
+  it 'exists' do
+    visit '/digitalstacks'
+
+    expect(page).to have_content('Digital Stacks Homepage')
+  end
+end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

This just sets up a new route, controller, and view for /digitalstacks, which is at the moment just a page that contains "Digital Stacks Homepage"

## Related Tickets & Documents

- Related Issue #62 
- Closes #

## QA Instructions, Screenshots, Recordings

Run RSpec tests, ensure none failing. 

To manually test, visit /digitalstacks and ensure you see "Digital Stacks Homepage"

## Added/updated tests?

- [x] Yes
- [ ] No, and this is why: _please replace this line with details on why tests
      have not been included_
- [ ] I need help with writing tests

## [optional] Are there any post deployment tasks we need to perform?
